### PR TITLE
Return early on CSRF mismatch in login

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -418,49 +418,34 @@ async def admin_login(request: Request):
     form = dict(await request.form())
     token = _get_csrf_from_form(form)
     if token != request.session.get("csrf_token"):
-        t = csrf_token(request)
-    resp = templates.TemplateResponse(
+        return templates.TemplateResponse(
             "admin_login.html",
-            {"request": request, "title": "Login", "error": "CSRF token invalid"},
-            status_code=400
+            {
+                "request": request,
+                "title": "Login",
+                "error": "CSRF token invalid",
+                "csrf": csrf_token(request),
+            },
+            status_code=400,
         )
+
     username = form.get("username", "")
     password = form.get("password", "")
-    if username == os.getenv("ADMIN_USER", "admin") and password == os.getenv("ADMIN_PASS", "admin"):
+    if username == settings.ADMIN_USER and password == settings.ADMIN_PASS:
         request.session["admin"] = True
         request.session["csrf_token"] = token_urlsafe(32)  # rotate token
         return RedirectResponse(url="/admin", status_code=303)
-    t = csrf_token(request)
-    resp = templates.TemplateResponse(
+
+    return templates.TemplateResponse(
         "admin_login.html",
-        {"request": request, "title": "Login", "error": "Invalid credentials"},
-        status_code=400
+        {
+            "request": request,
+            "title": "Login",
+            "error": "Invalid credentials",
+            "csrf": csrf_token(request),
+        },
+        status_code=400,
     )
-
-
-@app.post("/admin/login")
-async def admin_login_submit(request: Request,
-    username: str = Form(...),
-    password: str = Form(...),
-    csrf: str = Form(...)):
-    session_csrf = request.session.get("csrf_token")
-    if not session_csrf or csrf != session_csrf:
-        t = csrf_token(request)
-    resp = templates.TemplateResponse(
-            "admin_login.html",
-            {"request": request, "title": "Admin Login", "error": "Invalid CSRF token"},
-            status_code=400,
-        )
-    if username == "admin" and password == "admin":
-        request.session["admin"] = True
-        return RedirectResponse(url="/admin", status_code=303)
-    t = csrf_token(request)
-    resp = templates.TemplateResponse(
-        "admin_login.html",
-        {"request": request, "title": "Admin Login", "error": "Invalid credentials"},
-        status_code=401,
-    )
-
 
 @app.get("/admin/seed")
 def _admin_seed(request):

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,77 @@
+import asyncio
+import pathlib
+import sys
+import types
+import shutil
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Stub dependencies expected by app.py
+settings = types.SimpleNamespace(
+    ADMIN_USER="admin",
+    ADMIN_PASS="admin",
+    DATABASE_URL="sqlite://",
+    UPLOAD_DIR="uploads",
+    SECRET_KEY="change-me",
+)
+sys.modules['backend_settings'] = types.SimpleNamespace(settings=settings)
+
+class DummySession:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+    def exec(self, *a, **kw):
+        class R:
+            def all(self): return []
+            def first(self): return None
+            def one(self): return 0
+            def mappings(self): return self
+        return R()
+    def commit(self):
+        pass
+    def add(self, *a, **kw):
+        pass
+
+sys.modules['sqlmodel'] = types.SimpleNamespace(
+    Session=DummySession,
+    select=lambda *a, **k: None,
+    SQLModel=object,
+    create_engine=lambda *a, **k: None,
+)
+sys.modules['db'] = types.SimpleNamespace(engine=None, init_db=lambda: None)
+sys.modules['models'] = types.SimpleNamespace(Car=None, Media=None, ImportJob=None, Setting=None, AdminAudit=None)
+
+# Ensure required directories and template
+(ROOT / "static").mkdir(exist_ok=True)
+(ROOT / "uploads").mkdir(exist_ok=True)
+templates_dir = ROOT / "templates"
+if templates_dir.exists():
+    shutil.rmtree(templates_dir)
+templates_dir.mkdir()
+shutil.copy(ROOT / "backend" / "templates" / "admin_login.html", templates_dir / "admin_login.html")
+
+sys.path.append(str(ROOT))
+
+from backend.app import admin_login  # now import after stubs
+
+
+class DummyRequest:
+    def __init__(self, form, session=None):
+        self._form = form
+        self.session = session or {}
+    async def form(self):
+        return self._form
+
+
+def test_invalid_csrf_token_rejected():
+    req = DummyRequest(
+        {"username": settings.ADMIN_USER, "password": settings.ADMIN_PASS, "csrf": "bad"},
+        session={"csrf_token": "good"},
+    )
+    resp = asyncio.run(admin_login(req))
+    assert resp.status_code == 400
+    assert resp.context["error"] == "CSRF token invalid"
+    assert "admin" not in req.session


### PR DESCRIPTION
## Summary
- halt login processing and show error if CSRF token doesn't match
- cover CSRF failure with regression test

## Testing
- `pytest tests/test_csrf.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aefb9257208321ac36038d546ab78e