### PR TITLE
Add requests dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ Jinja2==3.1.4
 MarkupSafe==2.1.5
 
 sqladmin
+requests


### PR DESCRIPTION
## Summary
- Add missing `requests` library to backend requirements

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest`
- `python import_porsche.py backend/porshe.json` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68aefff1f3208321af5e6ecad7b6616b