### PR TITLE
Use relative default DATABASE_URL and document env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # VINFREAK
+
+## Configuration
+
+The backend uses a SQLite database stored at `backend/cars.db` by default.
+You can override this by setting the `DATABASE_URL` environment variable
+to point to a different database.

--- a/backend/backend_settings.py
+++ b/backend/backend_settings.py
@@ -8,7 +8,9 @@ class Settings(BaseSettings):
     APP_NAME: str = "Vinfreak Admin"
     ADMIN_USER: str = "admin"
     ADMIN_PASS: str = "admin"  # change later
-    DATABASE_URL: str = f"sqlite:////home/kali/Desktop/vinfreak/backend/cars.db"
+    # Default to a SQLite database in the backend directory; override via
+    # the DATABASE_URL environment variable for other databases.
+    DATABASE_URL: str = f"sqlite:///{BASE_DIR / 'cars.db'}"
     UPLOAD_DIR: str = (BASE_DIR / "uploads").as_posix()
     SECRET_KEY: str = "change-me"
 


### PR DESCRIPTION
## Summary
- default to a SQLite database located within the backend directory
- document database configuration and environment override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeffea88d48321a450ef3df58f6e77