### PR TITLE
Fix duplicate select import in backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,7 +7,7 @@ from starlette.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from typing import Optional, List
-from sqlmodel import Session as DBSession, select, select
+from sqlmodel import Session as DBSession, select
 from sqlalchemy import text
 from datetime import datetime, timedelta
 from pathlib import Path


### PR DESCRIPTION
## Summary
- fix redundant select import in backend app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeffe3b4a88321b235abdfc118ca16