### PR TITLE
Add sqlmodel dependency to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,4 +13,5 @@ Jinja2==3.1.4
 MarkupSafe==2.1.5
 
 sqladmin
+sqlmodel
 requests


### PR DESCRIPTION
## Summary
- include `sqlmodel` in backend requirements to resolve missing module errors during deployment

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlmodel, likely due to network restrictions)*
- `pytest tests/test_csrf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0637697c83219baf84280afafd85