### PR TITLE
Fix admin login session key to match checks

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -179,8 +179,11 @@ def public_settings():
 # -------- admin UI ----------
 @app.get("/admin", response_class=HTMLResponse)
 def admin_index(request: Request, _=Depends(admin_session_required)):
-    t = csrf_token(request)
-    resp = templates.TemplateResponse("admin_index.html", {"request": request, "title":"Dashboard", "flash": pop_flash(request)})
+    csrf_token(request)
+    return templates.TemplateResponse(
+        "admin_index.html",
+        {"request": request, "title": "Dashboard", "flash": pop_flash(request)},
+    )
 
 def allowed_sorts():
     return {"posted_at","id","price","year","mileage","make","model"}
@@ -425,6 +428,7 @@ async def admin_login(request: Request):
     username = form.get("username", "")
     password = form.get("password", "")
     if username == settings.ADMIN_USER and password == settings.ADMIN_PASS:
+        request.session["admin_user"] = username
         request.session["admin"] = True
         request.session["csrf_token"] = token_urlsafe(32)  # rotate token
         return RedirectResponse(url="/admin", status_code=303)

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -51,11 +51,12 @@ templates_dir = ROOT / "templates"
 if templates_dir.exists():
     shutil.rmtree(templates_dir)
 templates_dir.mkdir()
-shutil.copy(ROOT / "backend" / "templates" / "admin_login.html", templates_dir / "admin_login.html")
+for tmpl in ["admin_login.html", "admin_index.html", "_base.html"]:
+    shutil.copy(ROOT / "backend" / "templates" / tmpl, templates_dir / tmpl)
 
 sys.path.append(str(ROOT))
 
-from backend.app import admin_login  # now import after stubs
+from backend.app import admin_login, admin_index  # now import after stubs
 
 
 class DummyRequest:
@@ -75,3 +76,23 @@ def test_invalid_csrf_token_rejected():
     assert resp.status_code == 400
     assert resp.context["error"] == "CSRF token invalid"
     assert "admin" not in req.session
+    assert "admin_user" not in req.session
+
+
+def test_successful_login_sets_admin_user():
+    req = DummyRequest(
+        {"username": settings.ADMIN_USER, "password": settings.ADMIN_PASS, "csrf": "good"},
+        session={"csrf_token": "good"},
+    )
+    resp = asyncio.run(admin_login(req))
+    # Successful login should redirect
+    assert resp.status_code == 303
+    assert req.session.get("admin") is True
+    assert req.session.get("admin_user") == settings.ADMIN_USER
+
+
+def test_admin_dashboard_returns_template():
+    req = DummyRequest({}, session={"admin_user": settings.ADMIN_USER})
+    resp = admin_index(req)
+    template = getattr(resp, "template", None)
+    assert template and template.name == "admin_index.html"


### PR DESCRIPTION
## Summary
- Ensure successful login sets `admin_user` in the session for admin routes
- Extend tests to verify login session keys and CSRF rejection
- Return the admin dashboard template instead of a blank response and add test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0cd58c788321ad2bbf9dffde1552