### PR TITLE
Add taxonomy models and admin management

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,6 +1,7 @@
 from sqlmodel import create_engine, SQLModel, Session
 from sqlalchemy import text
 from backend_settings import settings
+from models import Make, Model, Category
 
 
 def ensure_columns():
@@ -13,6 +14,9 @@ def ensure_columns():
             "lot_number": "TEXT",
             "seller_rating": "REAL",
             "seller_reviews": "INTEGER",
+            "make_id": "INTEGER",
+            "model_id": "INTEGER",
+            "category_id": "INTEGER",
         }
         for col, typ in wanted.items():
             if col not in have:
@@ -29,6 +33,8 @@ engine = create_engine(
 
 def init_db():
     # Create non-cars tables from metadata
+    SQLModel.metadata.create_all(engine, tables=[Make.__table__, Model.__table__, Category.__table__])
+    ensure_columns()
     # --- ensure cars.lot_number exists for legacy DBs ---
     try:
         from sqlmodel import Session

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,13 +1,36 @@
 from typing import Optional
 from sqlmodel import SQLModel, Field
 
+
+class Make(SQLModel, table=True):
+    __tablename__ = "makes"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+
+class Model(SQLModel, table=True):
+    __tablename__ = "models"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    make_id: int | None = Field(default=None, foreign_key="makes.id")
+
+
+class Category(SQLModel, table=True):
+    __tablename__ = "categories"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+
 # NOTE: Car columns mirror existing DB plus optional deleted_at for soft delete.
 class Car(SQLModel, table=True):
     __tablename__ = "cars"
     id: int | None = Field(default=None, primary_key=True)
     vin: str | None = None
     make: str | None = None
+    make_id: int | None = Field(default=None, foreign_key="makes.id")
     model: str | None = None
+    model_id: int | None = Field(default=None, foreign_key="models.id")
+    category_id: int | None = Field(default=None, foreign_key="categories.id")
     trim: str | None = None
     year: int | None = None
     mileage: int | None = None

--- a/backend/templates/_base.html
+++ b/backend/templates/_base.html
@@ -23,6 +23,9 @@
       <a href="/admin/settings">Settings</a>
       <a href="/admin/cars">Cars</a>
       <a href="/admin/media">Media</a>
+      <a href="/admin/makes">Makes</a>
+      <a href="/admin/models">Models</a>
+      <a href="/admin/categories">Categories</a>
       <a href="/admin/imports">Imports</a>
       <a href="/admin/logout">Logout</a>
     </nav>

--- a/backend/templates/admin_car_edit.html
+++ b/backend/templates/admin_car_edit.html
@@ -6,8 +6,30 @@
   <div class="grid">
     <label>VIN <input name="vin" value="{{ car.vin if car else '' }}"></label>
     <label>Year <input type="number" name="year" value="{{ car.year if car else '' }}"></label>
-    <label>Make <input name="make" value="{{ car.make if car else '' }}"></label>
-    <label>Model <input name="model" value="{{ car.model if car else '' }}"></label>
+    <label>Make
+      <select name="make_id">
+        <option value=""></option>
+        {% for m in makes %}
+          <option value="{{ m.id }}" {{ 'selected' if car and car.make_id==m.id else '' }}>{{ m.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Model
+      <select name="model_id">
+        <option value=""></option>
+        {% for m in models %}
+          <option value="{{ m.id }}" {{ 'selected' if car and car.model_id==m.id else '' }}>{{ m.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Category
+      <select name="category_id">
+        <option value=""></option>
+        {% for c in categories %}
+          <option value="{{ c.id }}" {{ 'selected' if car and car.category_id==c.id else '' }}>{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
     <label>Trim <input name="trim" value="{{ car.trim if car else '' }}"></label>
     <label>Price <input type="number" step="0.01" name="price" value="{{ car.price if car else '' }}"></label>
     <label>Mileage <input type="number" name="mileage" value="{{ car.mileage if car else '' }}"></label>

--- a/backend/templates/admin_cars.html
+++ b/backend/templates/admin_cars.html
@@ -4,7 +4,24 @@
 
 <form class="filters" method="get" action="/admin/cars">
   <input type="text" name="q" value="{{ q or '' }}" placeholder="Search VIN, make, model, title…"/>
-  <input type="text" name="make" value="{{ make or '' }}" placeholder="Make"/>
+  <select name="make_id">
+    <option value="">All makes</option>
+    {% for m in makes %}
+      <option value="{{ m.id }}" {{ 'selected' if make_id==m.id else '' }}>{{ m.name }}</option>
+    {% endfor %}
+  </select>
+  <select name="model_id">
+    <option value="">All models</option>
+    {% for m in models %}
+      <option value="{{ m.id }}" {{ 'selected' if model_id==m.id else '' }}>{{ m.name }}</option>
+    {% endfor %}
+  </select>
+  <select name="category_id">
+    <option value="">All categories</option>
+    {% for c in categories %}
+      <option value="{{ c.id }}" {{ 'selected' if category_id==c.id else '' }}>{{ c.name }}</option>
+    {% endfor %}
+  </select>
   <select name="status">
     <option value="">Any status</option>
     {% for s in ['LIVE','SOLD','RESERVE_NOT_MET','ENDED','DRAFT'] %}
@@ -74,9 +91,9 @@
 </table>
 
 <div class="pager">
-  {% if page>1 %}<a href="?page={{ page-1 }}&per={{ per }}&q={{ q }}&make={{ make }}&status={{ status }}&year_min={{ year_min }}&year_max={{ year_max }}&sort={{ sort }}">« Prev</a>{% endif %}
+  {% if page>1 %}<a href="?page={{ page-1 }}&per={{ per }}&q={{ q }}&make_id={{ make_id }}&model_id={{ model_id }}&category_id={{ category_id }}&status={{ status }}&year_min={{ year_min }}&year_max={{ year_max }}&sort={{ sort }}">« Prev</a>{% endif %}
   <span>Page {{ page }} / {{ last_page }} ({{ total }} items)</span>
-  {% if page<last_page %}<a href="?page={{ page+1 }}&per={{ per }}&q={{ q }}&make={{ make }}&status={{ status }}&year_min={{ year_min }}&year_max={{ year_max }}&sort={{ sort }}">Next »</a>{% endif %}
+  {% if page<last_page %}<a href="?page={{ page+1 }}&per={{ per }}&q={{ q }}&make_id={{ make_id }}&model_id={{ model_id }}&category_id={{ category_id }}&status={{ status }}&year_min={{ year_min }}&year_max={{ year_max }}&sort={{ sort }}">Next »</a>{% endif %}
 </div>
 
 <script>

--- a/backend/templates/admin_categories.html
+++ b/backend/templates/admin_categories.html
@@ -1,0 +1,16 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>Categories</h1>
+<a class="button" href="/admin/categories/new">+ New Category</a>
+<table class="table">
+  <thead><tr><th>Name</th><th></th></tr></thead>
+  <tbody>
+  {% for c in items %}
+    <tr>
+      <td>{{ c.name }}</td>
+      <td><a href="/admin/categories/{{ c.id }}">Edit</a> | <a href="/admin/categories/{{ c.id }}/delete" onclick="return confirm('Delete?')">Delete</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/templates/admin_category_edit.html
+++ b/backend/templates/admin_category_edit.html
@@ -1,0 +1,9 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>{{ 'Edit' if item else 'New' }} Category</h1>
+<form class="form" method="post" action="{{ action }}">
+  <input type="hidden" name="csrf" value="{{ csrf }}">
+  <label>Name <input name="name" value="{{ item.name if item else '' }}"></label>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/backend/templates/admin_make_edit.html
+++ b/backend/templates/admin_make_edit.html
@@ -1,0 +1,9 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>{{ 'Edit' if item else 'New' }} Make</h1>
+<form class="form" method="post" action="{{ action }}">
+  <input type="hidden" name="csrf" value="{{ csrf }}">
+  <label>Name <input name="name" value="{{ item.name if item else '' }}"></label>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/backend/templates/admin_makes.html
+++ b/backend/templates/admin_makes.html
@@ -1,0 +1,16 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>Makes</h1>
+<a class="button" href="/admin/makes/new">+ New Make</a>
+<table class="table">
+  <thead><tr><th>Name</th><th></th></tr></thead>
+  <tbody>
+  {% for m in items %}
+    <tr>
+      <td>{{ m.name }}</td>
+      <td><a href="/admin/makes/{{ m.id }}">Edit</a> | <a href="/admin/makes/{{ m.id }}/delete" onclick="return confirm('Delete?')">Delete</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/templates/admin_model_edit.html
+++ b/backend/templates/admin_model_edit.html
@@ -1,0 +1,16 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>{{ 'Edit' if item else 'New' }} Model</h1>
+<form class="form" method="post" action="{{ action }}">
+  <input type="hidden" name="csrf" value="{{ csrf }}">
+  <label>Make
+    <select name="make_id">
+      {% for mk in makes %}
+        <option value="{{ mk.id }}" {{ 'selected' if item and item.make_id==mk.id else '' }}>{{ mk.name }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Name <input name="name" value="{{ item.name if item else '' }}"></label>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/backend/templates/admin_models.html
+++ b/backend/templates/admin_models.html
@@ -1,0 +1,17 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>Models</h1>
+<a class="button" href="/admin/models/new">+ New Model</a>
+<table class="table">
+  <thead><tr><th>Make</th><th>Name</th><th></th></tr></thead>
+  <tbody>
+  {% for m in items %}
+    <tr>
+      <td>{{ m.make_name }}</td>
+      <td>{{ m.name }}</td>
+      <td><a href="/admin/models/{{ m.id }}">Edit</a> | <a href="/admin/models/{{ m.id }}/delete" onclick="return confirm('Delete?')">Delete</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Make, Model, and Category models linked to cars
- provide admin CRUD views and navigation for taxonomies
- update car forms and filters to use taxonomy dropdowns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1ea8b1b08321b26a89971ab699ea