### PR TITLE
Add price range filter with UI and tests

### DIFF
--- a/frontend/src/components/Facets.jsx
+++ b/frontend/src/components/Facets.jsx
@@ -1,4 +1,12 @@
-export default function Facets({ sort, setSort, minYear, setMinYear, maxYear, setMaxYear, source, setSource, sources }) {
+export default function Facets({
+  sort, setSort,
+  minYear, setMinYear,
+  maxYear, setMaxYear,
+  minPrice, setMinPrice,
+  maxPrice, setMaxPrice,
+  source, setSource,
+  sources
+}) {
   return (
     <div className="facets">
       <label className="f">
@@ -20,6 +28,14 @@ export default function Facets({ sort, setSort, minYear, setMinYear, maxYear, se
       <label className="f">
         <span>Max Year</span>
         <input type="number" value={maxYear ?? ""} onChange={e=>setMaxYear(e.target.value?Number(e.target.value):null)} />
+      </label>
+      <label className="f">
+        <span>Min Price</span>
+        <input type="number" value={minPrice ?? ""} onChange={e=>setMinPrice(e.target.value?Number(e.target.value):null)} />
+      </label>
+      <label className="f">
+        <span>Max Price</span>
+        <input type="number" value={maxPrice ?? ""} onChange={e=>setMaxPrice(e.target.value?Number(e.target.value):null)} />
       </label>
       <label className="f">
         <span>Source</span>

--- a/frontend/src/components/priceFilter.test.js
+++ b/frontend/src/components/priceFilter.test.js
@@ -1,0 +1,33 @@
+import assert from "assert";
+
+const cars = [
+  { __price: 10000 },
+  { __price: 20000 },
+  { __price: 30000 },
+  { __price: null },
+];
+
+function filterByPrice(list, minPrice, maxPrice) {
+  return list.filter(c => {
+    const price = c.__price == null ? null : Number(c.__price);
+    const lowerOk = minPrice ? (price ?? 0) >= minPrice : true;
+    const upperOk = maxPrice ? (price ?? Infinity) <= maxPrice : true;
+    return lowerOk && upperOk;
+  });
+}
+
+assert.deepStrictEqual(
+  filterByPrice(cars, 15000, null).map(c => c.__price),
+  [20000, 30000]
+);
+assert.deepStrictEqual(
+  filterByPrice(cars, null, 25000).map(c => c.__price),
+  [10000, 20000]
+);
+assert.deepStrictEqual(
+  filterByPrice(cars, 15000, 25000).map(c => c.__price),
+  [20000]
+);
+
+console.log("Price filter tests passed");
+

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -19,6 +19,8 @@ export default function Home() {
   const [sort, setSort] = useState("relevance");
   const [minYear, setMinYear] = useState(null);
   const [maxYear, setMaxYear] = useState(null);
+  const [minPrice, setMinPrice] = useState(null);
+  const [maxPrice, setMaxPrice] = useState(null);
   const [source, setSource] = useState("");
 
   const [page, setPage] = useState(1);
@@ -65,9 +67,13 @@ export default function Home() {
       return hay.includes(text);
     };
     const byYear = (c) => (minYear ? (c.__year ?? 0) >= minYear : true) && (maxYear ? (c.__year ?? 9999) <= maxYear : true);
+    const byPrice = (c) => {
+      const price = c.__price == null ? null : Number(c.__price);
+      return (minPrice ? (price ?? 0) >= minPrice : true) && (maxPrice ? (price ?? Infinity) <= maxPrice : true);
+    };
     const bySource = (c) => source ? String(c.__source || "") === source : true;
-    return raw.filter(c => byText(c) && byYear(c) && bySource(c));
-  }, [raw, q, minYear, maxYear, source]);
+    return raw.filter(c => byText(c) && byYear(c) && byPrice(c) && bySource(c));
+  }, [raw, q, minYear, maxYear, minPrice, maxPrice, source]);
 
   const sorted = useMemo(() => {
     const arr = [...filtered];
@@ -90,7 +96,7 @@ export default function Home() {
   const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const start = (page-1)*PAGE_SIZE;
   const pageItems = sorted.slice(start, start + PAGE_SIZE);
-  useEffect(()=>{ setPage(1); }, [q, minYear, maxYear, source, sort, PAGE_SIZE]);
+  useEffect(()=>{ setPage(1); }, [q, minYear, maxYear, minPrice, maxPrice, source, sort, PAGE_SIZE]);
 
   return (
     <div>
@@ -114,6 +120,8 @@ export default function Home() {
           sort={sort} setSort={setSort}
           minYear={minYear} setMinYear={setMinYear}
           maxYear={maxYear} setMaxYear={setMaxYear}
+          minPrice={minPrice} setMinPrice={setMinPrice}
+          maxPrice={maxPrice} setMaxPrice={setMaxPrice}
           source={source} setSource={setSource}
           sources={availableSources}
         />
@@ -121,6 +129,8 @@ export default function Home() {
           {q && <Chip label={`q: ${q}`} onClear={()=>setQ("")} />}
           {minYear!=null && <Chip label={`≥ ${minYear}`} onClear={()=>setMinYear(null)} />}
           {maxYear!=null && <Chip label={`≤ ${maxYear}`} onClear={()=>setMaxYear(null)} />}
+          {minPrice!=null && <Chip label={`≥ ${fmtMoney(minPrice)}`} onClear={()=>setMinPrice(null)} />}
+          {maxPrice!=null && <Chip label={`≤ ${fmtMoney(maxPrice)}`} onClear={()=>setMaxPrice(null)} />}
           {source && <Chip label={source} onClear={()=>setSource("")} />}
         </div>
         <div className="results">{fmtNum(total)} result{total===1?"":"s"}</div>


### PR DESCRIPTION
## Summary
- allow users to set min and max price filters on the home page
- show price range inputs in the Facets component and display active price chips
- add unit test covering price filtering logic

## Testing
- `node frontend/src/components/priceFilter.test.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b16529e1c48321b7ddaa0bffae210f