### PR TITLE
Add accessible focus styles for filters

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -31,6 +31,13 @@ nav a.active{color:var(--accent);font-weight:700}
 .search{width:100%;padding:12px 14px;border-radius:12px;border:1px solid var(--border); background:rgba(8,12,26,.7); color:#fff; outline:none}
 .search:focus{box-shadow:0 0 0 3px #6ea8ff33;border-color:#6ea8ff66}
 
+.filters select:focus,
+.filters input:focus{
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
+  outline: none;
+}
+
 .toolbar-row{display:flex;flex-direction:column;gap:10px;margin:14px 0}
 .facets{display:flex;gap:10px;flex-wrap:wrap}
 .f{display:flex;flex-direction:column;gap:6px}


### PR DESCRIPTION
## Summary
- highlight focused filter inputs with an accent-colored outline for better accessibility

## Testing
- `pytest -q`
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b169233828832198907c4657811bb3