### PR TITLE
Add Dealership model and link cars to it

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,7 +1,7 @@
 from sqlmodel import create_engine, SQLModel, Session
 from sqlalchemy import text
 from backend_settings import settings
-from models import Make, Model, Category
+from models import Make, Model, Category, Dealership, Car
 
 
 def ensure_columns():
@@ -17,6 +17,7 @@ def ensure_columns():
             "make_id": "INTEGER",
             "model_id": "INTEGER",
             "category_id": "INTEGER",
+            "dealership_id": "INTEGER",
         }
         for col, typ in wanted.items():
             if col not in have:
@@ -33,7 +34,7 @@ engine = create_engine(
 
 def init_db():
     # Create non-cars tables from metadata
-    SQLModel.metadata.create_all(engine, tables=[Make.__table__, Model.__table__, Category.__table__])
+    SQLModel.metadata.create_all(engine, tables=[Make.__table__, Model.__table__, Category.__table__, Dealership.__table__])
     ensure_columns()
     # --- ensure cars.lot_number exists for legacy DBs ---
     try:
@@ -88,3 +89,24 @@ def init_db():
             if not r:
                 s.exec(text("INSERT INTO settings(key,value) VALUES (:k,:v)").bindparams(k=k, v=v))
         s.commit()
+        # Seed existing dealerships from seller_name if available
+        try:
+            rows = s.exec(
+                text(
+                    "SELECT DISTINCT seller_name FROM cars WHERE seller_name IS NOT NULL AND seller_name != ''"
+                )
+            ).all()
+            for (name,) in rows:
+                s.exec(text("INSERT OR IGNORE INTO dealerships(name) VALUES (:n)").bindparams(n=name))
+                s.exec(
+                    text(
+                        """
+                        UPDATE cars
+                        SET dealership_id = (SELECT id FROM dealerships WHERE name=:n)
+                        WHERE seller_name = :n AND (dealership_id IS NULL OR dealership_id = 0)
+                        """
+                    ).bindparams(n=name)
+                )
+            s.commit()
+        except Exception as e:
+            print("init_db: dealership seed failed:", e)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from typing import ClassVar
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
 from pydantic import ConfigDict, BaseModel
 
 # Allow "model_*" field names globally
@@ -25,6 +25,15 @@ class Category(SQLModel, table=True):
     name: str
 
 
+class Dealership(SQLModel, table=True):
+    __tablename__ = "dealerships"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    logo_url: str | None = None
+
+    cars: list["Car"] = Relationship(back_populates="dealership")
+
+
 # NOTE: Car columns mirror existing DB plus optional deleted_at for soft delete.
 class Car(SQLModel, table=True):
     __tablename__ = "cars"
@@ -37,6 +46,7 @@ class Car(SQLModel, table=True):
     model: str | None = None
     model_id: int | None = Field(default=None, foreign_key="models.id")
     category_id: int | None = Field(default=None, foreign_key="categories.id")
+    dealership_id: int | None = Field(default=None, foreign_key="dealerships.id")
     trim: str | None = None
     year: int | None = None
     mileage: int | None = None
@@ -56,6 +66,8 @@ class Car(SQLModel, table=True):
     seller_reviews: str | None = None
     posted_at: str | None = None
     deleted_at: str | None = None  # soft delete (TEXT ISO8601)
+
+    dealership: Dealership | None = Relationship(back_populates="cars")
 
 class Media(SQLModel, table=True):
     __tablename__ = "media"


### PR DESCRIPTION
## Summary
- introduce Dealership model with id, name and logo_url
- relate cars to dealerships via `dealership_id`
- seed existing seller names into Dealership table when initializing DB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b171a900a8832187407fb6fc34ad2f