### PR TITLE
Add dealership admin management and auditing

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from typing import ClassVar
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
 from pydantic import ConfigDict, BaseModel
 
 # Allow "model_*" field names globally
@@ -23,6 +23,14 @@ class Category(SQLModel, table=True):
     __tablename__ = "categories"
     id: int | None = Field(default=None, primary_key=True)
     name: str
+
+
+class Dealership(SQLModel, table=True):
+    __tablename__ = "dealerships"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    logo: str | None = None  # stored filename in uploads/
+    cars: list["Car"] = Relationship(back_populates="dealership")
 
 
 # NOTE: Car columns mirror existing DB plus optional deleted_at for soft delete.
@@ -55,6 +63,8 @@ class Car(SQLModel, table=True):
     seller_rating: str | None = None
     seller_reviews: str | None = None
     posted_at: str | None = None
+    dealership_id: int | None = Field(default=None, foreign_key="dealerships.id")
+    dealership: Dealership | None = Relationship(back_populates="cars")
     deleted_at: str | None = None  # soft delete (TEXT ISO8601)
 
 class Media(SQLModel, table=True):

--- a/backend/templates/admin_car_edit.html
+++ b/backend/templates/admin_car_edit.html
@@ -30,6 +30,14 @@
         {% endfor %}
       </select>
     </label>
+    <label>Dealership
+      <select name="dealership_id">
+        <option value=""></option>
+        {% for d in dealerships %}
+          <option value="{{ d.id }}" {{ 'selected' if car and car.dealership_id==d.id else '' }}>{{ d.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
     <label>Trim <input name="trim" value="{{ car.trim if car else '' }}"></label>
     <label>Price <input type="number" step="0.01" name="price" value="{{ car.price if car else '' }}"></label>
     <label>Mileage <input type="number" name="mileage" value="{{ car.mileage if car else '' }}"></label>

--- a/backend/templates/admin_cars.html
+++ b/backend/templates/admin_cars.html
@@ -67,7 +67,7 @@
 <table class="table">
   <thead><tr>
     <th><input type="checkbox" id="chk_all" onclick="toggleAll(this)"></th>
-    <th>Thumb</th><th>Title</th><th>VIN</th><th>Year</th><th>Price</th><th>Status</th><th>Source</th><th></th>
+    <th>Thumb</th><th>Title</th><th>VIN</th><th>Year</th><th>Price</th><th>Status</th><th>Source</th><th>Dealership</th><th></th>
   </tr></thead>
   <tbody>
   {% for c in cars %}
@@ -84,6 +84,7 @@
       <td>{{ (("{:,.0f}".format(c.price)) if c.price else "") ~ " " ~ (c.currency or "") }}</td>
       <td>{{ c.auction_status or '' }}</td>
       <td>{{ c.source or '' }}</td>
+      <td>{% if c.dealership_name %}<span class="badge dealership">{{ c.dealership_name }}</span>{% endif %}</td>
       <td><a href="/admin/cars/{{ c.id }}">Edit</a> | <a href="/admin/cars/{{ c.id }}/delete" onclick="return confirm('Delete?')">Delete</a></td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- introduce Dealership model and relation on Car
- extend admin views with DealershipAdmin and dealership selection for cars
- track dealership changes in audit logs and surface dealership column in car listings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b171ab03408321a1049a118c6e330c