### PR TITLE
Fix dealership imports and mapping

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,6 +1,7 @@
 from sqlmodel import create_engine, SQLModel, Session
 from sqlalchemy import text
 from backend_settings import settings
+from models import Make, Model, Category, Dealership
 
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -29,7 +29,9 @@ class Dealership(SQLModel, table=True):
     __tablename__ = "dealerships"
     id: int | None = Field(default=None, primary_key=True)
     name: str
+    logo_url: str | None = None
 
+    cars: list["Car"] = Relationship(back_populates="dealership")
 
 
 # NOTE: Car columns mirror existing DB plus optional deleted_at for soft delete.
@@ -63,10 +65,7 @@ class Car(SQLModel, table=True):
     seller_rating: str | None = None
     seller_reviews: str | None = None
     posted_at: str | None = None
-    dealership_id: int | None = Field(default=None, foreign_key="dealerships.id")
-    dealership: Dealership | None = Relationship(back_populates="cars")
     deleted_at: str | None = None  # soft delete (TEXT ISO8601)
-    dealership_id: int | None = Field(default=None, foreign_key="dealerships.id")
 
     dealership: Dealership | None = Relationship(back_populates="cars")
 


### PR DESCRIPTION
## Summary
- import Make/Model/Category/Dealership in database initialization to avoid NameError
- clean up Dealership and Car models with proper relationships and logo support

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b170f56a188321a7a065b1444af9e2