### PR TITLE
Fix car edit ID parsing and support SPA car route

### DIFF
--- a/frontend/src/pages/CarDetail.jsx
+++ b/frontend/src/pages/CarDetail.jsx
@@ -31,10 +31,15 @@ export default function CarDetail() {
         const data = await getJSON(`/cars/${encodeURIComponent(id)}`);
         setCar(data);
       } catch (e) {
-        addToast(String(e), "error");
+        try {
+          const alt = await getJSON(`/car/${encodeURIComponent(id)}`);
+          setCar(alt);
+        } catch (e2) {
+          addToast(String(e2), "error");
+        }
       } finally { setLoading(false); }
     })();
-  }, [id]);
+  }, [id, addToast]);
 
   const images = useMemo(()=> {
     if (!car) return [];


### PR DESCRIPTION
## Summary
- handle blank numeric fields when creating or editing cars in admin panel
- serve built frontend for root and `/car/{id}` routes, falling back to JSON if assets missing
- try legacy `/car/{id}` endpoint when `/cars/{id}` lookup fails so car pages still load on older backends

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17ee87530832196dc3056f0acd433