### PR TITLE
Serve SPA index for unknown paths

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1067,3 +1067,9 @@ def frontend_root():
 
 
 
+@app.get("/{path_name:path}", response_class=HTMLResponse)
+def frontend_fallback(path_name: str):
+    if FRONTEND_INDEX.exists():
+        return HTMLResponse(FRONTEND_INDEX.read_text())
+    raise HTTPException(status_code=404, detail="Frontend not built")
+


### PR DESCRIPTION
## Summary
- Serve frontend index.html for any unmatched path to prevent 404 on deep links like `/car/12`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b185fe30c083218ddb7d41f41b926a