### PR TITLE
Serve SPA index for unknown paths

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,13 @@
 from secrets import token_urlsafe
 import hmac
 from fastapi import FastAPI, Request, Depends, Form, UploadFile, File, Response, HTTPException, Query
-from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import (
+    HTMLResponse,
+    RedirectResponse,
+    StreamingResponse,
+    JSONResponse,
+    FileResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
@@ -1062,8 +1068,14 @@ else:
 @app.get("/", response_class=HTMLResponse)
 def frontend_root():
     if FRONTEND_INDEX.exists():
-        return HTMLResponse(FRONTEND_INDEX.read_text())
+        return FileResponse(FRONTEND_INDEX)
     raise HTTPException(status_code=404, detail="Frontend not built")
 
 
+@app.get("/{path_name:path}", response_class=HTMLResponse)
+def frontend_fallback(path_name: str, request: Request):
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept and FRONTEND_INDEX.exists():
+        return FileResponse(FRONTEND_INDEX)
+    raise HTTPException(status_code=404, detail="Not found")
 


### PR DESCRIPTION
## Summary
- Serve built `index.html` via `FileResponse` for any unmatched GET that accepts HTML
- Ensure deep links like `/car/12` render the SPA instead of returning 404

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b185fe30c083218ddb7d41f41b926a