### PR TITLE
Serve SPA index for unknown paths

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,13 @@
 from secrets import token_urlsafe
 import hmac
 from fastapi import FastAPI, Request, Depends, Form, UploadFile, File, Response, HTTPException, Query
-from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import (
+    HTMLResponse,
+    RedirectResponse,
+    StreamingResponse,
+    JSONResponse,
+    FileResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
@@ -1062,8 +1068,14 @@ else:
 @app.get("/", response_class=HTMLResponse)
 def frontend_root():
     if FRONTEND_INDEX.exists():
-        return HTMLResponse(FRONTEND_INDEX.read_text())
+        return FileResponse(FRONTEND_INDEX)
     raise HTTPException(status_code=404, detail="Frontend not built")
 
 
+@app.get("/{path_name:path}", response_class=HTMLResponse)
+def frontend_fallback(path_name: str, request: Request):
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept and FRONTEND_INDEX.exists():
+        return FileResponse(FRONTEND_INDEX)
+    raise HTTPException(status_code=404, detail="Not found")
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,9 +1,10 @@
 // Unified API helper that supports both array and {items,total,...} responses
 const DEFAULT_BASE = (() => {
   const orig = window.location.origin;
-  // If hosted on a split Render setup (frontend at -1 domain, backend without),
-  // rewrite the origin to point to the backend.
-  if (orig.match(/-1\.onrender\.com$/)) return orig.replace(/-1\.onrender\.com$/, ".onrender.com");
+  // If hosted on a split Render setup (frontend at -N domain, backend without),
+  // rewrite the origin to point to the backend by dropping the dash-number suffix.
+  const m = orig.match(/^(https?:\/\/[^/]+?)-\d+\.onrender\.com$/);
+  if (m) return `${m[1]}.onrender.com`;
   return orig;
 })();
 const BASE = (import.meta.env.VITE_API_BASE ?? DEFAULT_BASE).replace(/\/+$/, "");

--- a/frontend/src/pages/CarDetail.jsx
+++ b/frontend/src/pages/CarDetail.jsx
@@ -31,13 +31,10 @@ export default function CarDetail() {
         const data = await getJSON(`/cars/${encodeURIComponent(id)}`);
         setCar(data);
       } catch (e) {
-        try {
-          const alt = await getJSON(`/car/${encodeURIComponent(id)}`);
-          setCar(alt);
-        } catch (e2) {
-          addToast(String(e2), "error");
-        }
-      } finally { setLoading(false); }
+        addToast(String(e), "error");
+      } finally {
+        setLoading(false);
+      }
     })();
   }, [id, addToast]);
 


### PR DESCRIPTION
## Summary
- Serve built `index.html` via `FileResponse` for any unmatched GET that accepts HTML
- Ensure deep links like `/car/12` render the SPA instead of returning 404
- Normalize frontend API base to drop Render numeric suffix and always target backend
- Remove outdated `/car/:id` fallback in `CarDetail` so requests hit `/cars/:id` consistently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b185fe30c083218ddb7d41f41b926a