### PR TITLE
Fix missing HTMLResponse import

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from secrets import token_urlsafe
 import hmac
 from fastapi import FastAPI, Request, Depends, Form, UploadFile, File, Response, HTTPException, Query
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware


### PR DESCRIPTION
## Summary
- Import HTMLResponse and RedirectResponse in backend app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b190ed4e088321a8d875b523696b65