### PR TITLE
Default API base to current origin

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 // Unified API helper that supports both array and {items,total,...} responses
 const DEFAULT_BASE = (() => {
   const orig = window.location.origin;
-
+  return orig;
 })();
 
 // Allow an explicit VITE_API_BASE but fall back to DEFAULT_BASE for empty strings


### PR DESCRIPTION
## Summary
- Ensure frontend API helper falls back to window.location.origin when no VITE_API_BASE is provided.

## Testing
- `npm run build`
- `rg -n -o "location.origin" dist/assets/index-B5zQhLja.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1930309048321afc8b773c56bb63f