### PR TITLE
Fix API base URL for Render deployment

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,8 @@
 // Unified API helper that supports both array and {items,total,...} responses
 const DEFAULT_BASE = (() => {
-  const orig = window.location.origin;
-  return orig;
+  const { protocol, hostname, port } = window.location;
+  const apiHost = hostname.replace(/-1(?=\.onrender\.com$)/, "");
+  return `${protocol}//${apiHost}${port ? ':' + port : ''}`;
 })();
 
 // Allow an explicit VITE_API_BASE but fall back to DEFAULT_BASE for empty strings


### PR DESCRIPTION
## Summary
- Ensure frontend API requests default to the backend hostname by stripping the `-1` suffix used for the static frontend deployment.

## Testing
- `npm --prefix frontend run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b191edac308321958c89e28dfd91b4