### PR TITLE
Fix frontend API base resolution

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -14,6 +14,11 @@ const DEFAULT_BASE = (() => {
   return origin;
 })();
 
+// Final API base URL. Use VITE_API_BASE env var if provided at build time
+// (e.g. when the frontend is served from a different domain), otherwise
+// fall back to the origin-derived default above.
+const BASE = import.meta.env.VITE_API_BASE || DEFAULT_BASE;
+
 
 // Generic JSON fetch with timeout
 export async function getJSON(path, { timeoutMs = 12000 } = {}) {


### PR DESCRIPTION
## Summary
- derive backend API base from current origin and allow override via `VITE_API_BASE`

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b19f8733188321940bfc9ab472f5b7