### PR TITLE
Handle empty dealership IDs and fix logo domains

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import { createContext, useEffect, useState } from "react";
 import Home from "./pages/Home";
 import CarDetail from "./pages/CarDetail";
 import ErrorBoundary from "./components/ErrorBoundary";
-import { getSettings } from "./api";
+import { getSettings, API_BASE } from "./api";
 import { useToast } from "./ToastContext";
 
 export const SettingsContext = createContext({
@@ -51,11 +51,12 @@ export default function App() {
         )}
         <header className="app-header">
           <Link to="/" className="logo">
-            {settings.logo_url ? (
-              <img src={settings.logo_url} alt={settings.site_title} />
-            ) : (
-              settings.site_title
-            )}
+            {(() => {
+              const u = settings.logo_url;
+              if (!u) return settings.site_title;
+              const src = u.startsWith("http") ? u : `${API_BASE}${u}`;
+              return <img src={src} alt={settings.site_title} />;
+            })()}
           </Link>
           <nav>
             <NavLink to="/" end className={({ isActive }) => (isActive ? "active" : "")}>Cars</NavLink>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -22,6 +22,7 @@ const DEFAULT_BASE = (() => {
 // (e.g. when the frontend is served from a different domain), otherwise
 // fall back to the origin-derived default above.
 const BASE = import.meta.env.VITE_API_BASE || DEFAULT_BASE;
+export const API_BASE = BASE;
 
 
 // Generic JSON fetch with timeout

--- a/frontend/src/components/DealershipLogo.jsx
+++ b/frontend/src/components/DealershipLogo.jsx
@@ -1,16 +1,21 @@
+import { API_BASE } from "../api";
+
 export default function DealershipLogo({ dealership }) {
   if (!dealership || !dealership.logo_url) return null;
-  const url = dealership.logo_url.startsWith('http')
-    ? dealership.logo_url
-    : dealership.logo_url.startsWith('/')
-      ? dealership.logo_url
-      : `/logos/${dealership.logo_url}`;
+  let url = dealership.logo_url;
+  if (url.startsWith("http")) {
+    // use as-is
+  } else if (url.startsWith("/")) {
+    url = `${API_BASE}${url}`;
+  } else {
+    url = `/logos/${url}`;
+  }
   return (
     <img
       className="dealership-logo"
       src={url}
-      alt={dealership.name || 'dealership'}
-      title={dealership.name || ''}
+      alt={dealership.name || "dealership"}
+      title={dealership.name || ""}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Avoid validation errors when bulk assigning dealerships by coercing empty IDs to `None`
- Expose API base URL to frontend and prefix uploaded logo paths so images load from backend domain
- Use backend base for site logo URLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a49de7848321bb2ece53a9922d16