### PR TITLE
Display dealership logo on detail page

### DIFF
--- a/frontend/src/pages/CarDetail.jsx
+++ b/frontend/src/pages/CarDetail.jsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import { getJSON } from "../api";
 import Gallery from "../components/Gallery";
 import SourceLogo from "../components/SourceLogo";
+import DealershipLogo from "../components/DealershipLogo";
 import { fmtMoney, fmtNum, fmtDate, toList } from "../utils/text";
 import { useToast } from "../ToastContext";
 
@@ -83,6 +84,7 @@ export default function CarDetail() {
           <h1>{title}</h1>
           <div className="hero-meta">
             {car.auction_status?.toUpperCase()==="SOLD" && <span className="ribbon sm">SOLD</span>}
+            {car.dealership && <DealershipLogo dealership={car.dealership} />}
             {!sourceHidden && <SourceLogo source={car.source} />}
           </div>
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -53,8 +53,9 @@ nav a.active{color:var(--accent);font-weight:700}
 .card-head{display:flex;align-items:start;gap:10px}
 .ctitle{text-decoration:none;font-weight:800}
 .meta{margin-left:auto;display:flex;align-items:center;gap:6px}
+.hero-meta{display:flex;align-items:center;gap:6px}
 .source-logo{width:22px;height:22px;object-fit:contain;display:block}
-.dealership-logo{width:22px;height:22px;object-fit:contain;display:block}
+.dealership-logo{width:40px;height:40px;object-fit:cover;display:block;border-radius:50%}
 
 .brief{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
 .badge{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;border:1px solid var(--border); background:rgba(255,255,255,.06); font-size:12px}


### PR DESCRIPTION
## Summary
- show dealership logo beside source info on car detail page
- add styling for detail page metadata row

## Testing
- `pytest`
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68b2204e670083219d71bbbf07a87abd