### PR TITLE
fix: ensure auction_status column

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -13,6 +13,7 @@ def ensure_columns():
         have = {row[1] for row in info}
         wanted = {
             "lot_number": "TEXT",
+            "auction_status": "TEXT",
             "seller_rating": "REAL",
             "seller_reviews": "INTEGER",
             "make_id": "INTEGER",


### PR DESCRIPTION
## Summary
- add auction_status to ensure_columns to create column if missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2a27a1d3c8321a50b427687f45bbc