### PR TITLE
Improve currency formatting and pricing display

### DIFF
--- a/frontend/src/pages/CarDetail.jsx
+++ b/frontend/src/pages/CarDetail.jsx
@@ -12,7 +12,7 @@ const SHOW_KEYS = [
   ["Year","year"], ["Make","make"], ["Model","model"], ["Trim","trim"],
   ["Body","body_type"], ["Engine","engine"], ["Fuel","fuel_type"], ["Transmission","transmission"],
   ["Drivetrain","drivetrain"], ["Exterior","exterior_color"], ["Interior","interior_color"],
-  ["Mileage","mileage"], ["Price","price"], ["Currency","currency"], ["Location","location"],
+  ["Mileage","mileage"], ["Price","price"], ["Location","location"],
   ["City","city"], ["State","state"], ["Seller","seller_name"], ["Seller Type","seller_type"],
   ["Auction","auction_status"], ["Lot #","lot_number"], 
   ["Views","number_of_views"], ["Bids","number_of_bids"],

--- a/frontend/src/utils/text.js
+++ b/frontend/src/utils/text.js
@@ -2,7 +2,17 @@ export const fmtNum = (v, d=0) => {
   if (v === null || v === undefined || v === "" || isNaN(Number(v))) return "—";
   return Number(v).toLocaleString(undefined, { maximumFractionDigits: d });
 };
-export const fmtMoney = (v, cur="USD") => (v==null? "—" : `${cur==="USD"?"$":""}${fmtNum(v)}`);
+export const fmtMoney = (v, cur="USD") => {
+  if (v == null) return "—";
+  if (cur === "USD") {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(v);
+  }
+  return `${fmtNum(v)} ${cur}`;
+};
 export const fmtDate = (iso) => {
   if (!iso) return "—";
   const d = new Date(iso);


### PR DESCRIPTION
## Summary
- Use `Intl.NumberFormat` for USD prices and append code for other currencies
- Drop separate currency spec on car detail page; rely on formatter output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2d63fd8ec83219a1b03a4b1be96d9