### PR TITLE
Add import tracking and deletion for uploaded car lists

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -20,6 +20,7 @@ def ensure_columns():
             "model_id": "INTEGER",
             "category_id": "INTEGER",
             "dealership_id": "INTEGER",
+            "import_job_id": "INTEGER",
             "seller_type": "TEXT",
             "exterior_color": "TEXT",
             "interior_color": "TEXT",
@@ -110,4 +111,5 @@ def init_db():
         s.exec(text("CREATE INDEX IF NOT EXISTS idx_cars_model ON cars(model)"))
         s.exec(text("CREATE INDEX IF NOT EXISTS idx_cars_posted_at ON cars(posted_at)"))
         s.exec(text("CREATE INDEX IF NOT EXISTS idx_cars_status ON cars(auction_status)"))
+        s.exec(text("CREATE INDEX IF NOT EXISTS idx_cars_import_job ON cars(import_job_id)"))
         s.commit()

--- a/backend/models.py
+++ b/backend/models.py
@@ -47,6 +47,7 @@ class Car(SQLModel, table=True):
     model_id: int | None = Field(default=None, foreign_key="models.id")
     category_id: int | None = Field(default=None, foreign_key="categories.id")
     dealership_id: int | None = Field(default=None, foreign_key="dealerships.id")
+    import_job_id: int | None = Field(default=None, foreign_key="import_jobs.id")
     trim: str | None = None
     year: int | None = None
     mileage: int | None = None

--- a/backend/templates/admin_imports.html
+++ b/backend/templates/admin_imports.html
@@ -10,7 +10,7 @@
 
 <table class="table">
   <thead><tr>
-    <th>ID</th><th>Source</th><th>Status</th><th>Items</th><th>Started</th><th>Finished</th><th>Errors</th><th>Actions</th>
+    <th>ID</th><th>Source</th><th>Status</th><th>Cars</th><th>Started</th><th>Finished</th><th>Errors</th><th>Actions</th>
   </tr></thead>
   <tbody>
   {% for j in jobs %}
@@ -18,7 +18,7 @@
       <td><a href="/admin/imports/{{ j.id }}">{{ j.id }}</a></td>
       <td>{{ j.source }}</td>
       <td>{{ j.status }}</td>
-      <td>{{ j.created_items }}/{{ j.total_items }}</td>
+      <td>{{ j.car_count }}</td>
       <td>{{ j.started_at }}</td>
       <td>{{ j.finished_at }}</td>
       <td>{{ (j.errors[:80] ~ '…') if j.errors and j.errors|length>80 else (j.errors or '') }}</td>
@@ -30,6 +30,10 @@
           <button type="submit">Cancel</button>
         </form>
         {% endif %}
+        <form method="post" action="/admin/imports/{{ j.id }}/delete" style="display:inline">
+          <input type="hidden" name="csrf" value="{{ csrf }}">
+          <button type="submit">Delete</button>
+        </form>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- link each imported car to an ImportJob so uploads can be tracked
- show imported car counts in admin import list and allow removing an import
- ensure database supports the new import job linkage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2d87334b08321b343ff47e5425fb0