### PR TITLE
Add rich car details and image galleries to imports

### DIFF
--- a/backend/dbupdate.py
+++ b/backend/dbupdate.py
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS cars (
     year INTEGER,
     mileage INTEGER,
     price REAL,
+    currency TEXT,
     city TEXT,
     state TEXT,
     seller_type TEXT,
@@ -33,8 +34,24 @@ CREATE TABLE IF NOT EXISTS cars (
     drivetrain TEXT,
     fuel_type TEXT,
     body_type TEXT,
+    auction_status TEXT,
+    end_time TEXT,
+    time_left TEXT,
+    number_of_views INTEGER,
+    number_of_bids INTEGER,
+    description TEXT,
+    highlights TEXT,
+    equipment TEXT,
+    modifications TEXT,
+    known_flaws TEXT,
+    service_history TEXT,
+    ownership_history TEXT,
+    seller_notes TEXT,
+    other_items TEXT,
+    engine TEXT,
     posted_at TEXT,
     image_url TEXT,
+    images_json TEXT,
     source TEXT,
     url TEXT
 )
@@ -44,10 +61,15 @@ CREATE TABLE IF NOT EXISTS cars (
 for car in data:
     cur.execute("""
     INSERT OR REPLACE INTO cars (
-        vin, make, model, trim, year, mileage, price, city, state, seller_type,
+        vin, make, model, trim, year, mileage, price, currency, city, state, seller_type,
         exterior_color, interior_color, transmission, drivetrain, fuel_type,
-        body_type, posted_at, image_url, source, url
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        body_type, auction_status, end_time, time_left, number_of_views, number_of_bids,
+        description, highlights, equipment, modifications, known_flaws, service_history,
+        ownership_history, seller_notes, other_items, engine,
+        posted_at, image_url, images_json, source, url
+    ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    )
     """, (
         car.get("vin"),
         car.get("make"),
@@ -56,6 +78,7 @@ for car in data:
         car.get("year"),
         car.get("mileage"),
         car.get("price"),
+        car.get("currency"),
         car.get("city"),
         car.get("state"),
         car.get("seller_type"),
@@ -65,8 +88,24 @@ for car in data:
         car.get("drivetrain"),
         car.get("fuel_type"),
         car.get("body_type"),
+        car.get("auction_status"),
+        car.get("end_time"),
+        car.get("time_left"),
+        car.get("number_of_views"),
+        car.get("number_of_bids"),
+        car.get("description"),
+        car.get("highlights"),
+        car.get("equipment"),
+        car.get("modifications"),
+        car.get("known_flaws"),
+        car.get("service_history"),
+        car.get("ownership_history"),
+        car.get("seller_notes"),
+        car.get("other_items"),
+        car.get("engine"),
         car.get("posted_at", datetime.utcnow().isoformat()),
         car.get("image_url"),
+        car.get("images_json"),
         car.get("source", "imported"),
         car.get("url")
     ))

--- a/backend/import_carsandbids.py
+++ b/backend/import_carsandbids.py
@@ -49,9 +49,10 @@ def map_price(obj):
     except:
         return None
 
-def map_image(obj):
-    imgs = obj.get("images") or []
-    return imgs[0] if imgs else None
+def join_list(lst):
+    if isinstance(lst, list):
+        return " \u2022 ".join([str(x).strip() for x in lst if str(x).strip()])
+    return None
 
 def normalize(item):
     title = item.get("title") or ""
@@ -72,8 +73,29 @@ def normalize(item):
     interior_color = item.get("interiorColor")
     body_type = map_body_type(item)
     seller_type = item.get("sellerType")
-    image_url = map_image(item)
+    images = item.get("images") or []
+    image_url = images[0] if images else None
+    images_json = json.dumps(images, ensure_ascii=False) if images else None
     url = item.get("url")
+
+    # text/detail fields
+    description = item.get("description")
+    highlights = item.get("highlights") or join_list(item.get("highlightsList"))
+    equipment = item.get("equipment") or join_list(item.get("equipmentList"))
+    modifications = join_list(item.get("modificationsList"))
+    known_flaws = join_list(item.get("knownFlowsList") or item.get("knownFlawsList"))
+    service_history = join_list(item.get("serviceHistoryList"))
+    ownership_history = item.get("ownershipHistory")
+    seller_notes = item.get("sellerNotes")
+    other_items = item.get("otherItems")
+    engine = item.get("engine")
+
+    auction_status = item.get("auctionStatus") or item.get("status")
+    end_time = item.get("endTime")
+    time_left = item.get("timeLeft")
+    number_of_views = item.get("numberOfViews")
+    number_of_bids = item.get("numberOfBids")
+    currency = (item.get("offer") or {}).get("currency")
 
     trim = None
     if make and model and title:
@@ -102,6 +124,7 @@ def normalize(item):
         "year": int(year),
         "mileage": m_val,
         "price": price,
+        "currency": currency,
         "city": city,
         "state": state,
         "seller_type": seller_type,
@@ -111,8 +134,24 @@ def normalize(item):
         "drivetrain": drivetrain,
         "fuel_type": None,
         "body_type": body_type,
+        "auction_status": auction_status,
+        "end_time": end_time,
+        "time_left": time_left,
+        "number_of_views": number_of_views,
+        "number_of_bids": number_of_bids,
+        "description": description,
+        "highlights": highlights,
+        "equipment": equipment,
+        "modifications": modifications,
+        "known_flaws": known_flaws,
+        "service_history": service_history,
+        "ownership_history": ownership_history,
+        "seller_notes": seller_notes,
+        "other_items": other_items,
+        "engine": engine,
         "posted_at": None,
         "image_url": image_url,
+        "images_json": images_json,
         "source": "carsandbids",
         "url": url,
     }

--- a/backend/import_from_json.py
+++ b/backend/import_from_json.py
@@ -76,6 +76,7 @@ def normalize(item):
     url = item.get("url")
     images = item.get("images") or []
     image_url = images[0] if images else None
+    images_json = json.dumps(images, ensure_ascii=False) if images else None
 
     # extra meta
     auction_status = item.get("auctionStatus") or item.get("status")
@@ -143,7 +144,7 @@ def normalize(item):
         "other_items": other_items,
         "engine": item.get("engine"),
         "image_url": image_url,
-        "images": images,
+        "images_json": images_json,
         "location_address": address,
         "location_url": location_url,
         "seller_name": seller_name,

--- a/backend/import_porsche.py
+++ b/backend/import_porsche.py
@@ -47,9 +47,6 @@ def map_price(obj):
     except:
         return None
 
-def map_image(obj):
-    imgs = obj.get("images") or []
-    return imgs[0] if imgs else None
 
 def join_list(lst):
     if isinstance(lst, list):
@@ -75,7 +72,9 @@ def normalize(item):
     interior_color = item.get("interiorColor")
     body_type = map_body_type(item)
     seller_type = item.get("sellerType")
-    image_url = map_image(item)
+    images = item.get("images") or []
+    image_url = images[0] if images else None
+    images_json = json.dumps(images, ensure_ascii=False) if images else None
     url = item.get("url")
 
     # extras
@@ -128,6 +127,7 @@ def normalize(item):
         "body_type": body_type,
         "posted_at": None,
         "image_url": image_url,
+        "images_json": images_json,
         "source": "carsandbids",
         "url": url,
         "engine": engine,

--- a/import_porsche.py
+++ b/import_porsche.py
@@ -67,7 +67,9 @@ def normalize(item):
     interior_color = item.get("interiorColor")
     body_type = (item.get("bodyStayle") or item.get("bodyStyle"))
     seller_type = item.get("sellerType")
-    image_url = (item.get("images") or [None])[0]
+    images = item.get("images") or []
+    image_url = images[0] if images else None
+    images_json = json.dumps(images, ensure_ascii=False) if images else None
     url = item.get("url")
 
     # extras
@@ -120,6 +122,7 @@ def normalize(item):
         "body_type": body_type,
         "posted_at": None,
         "image_url": image_url,
+        "images_json": images_json,
         "source": "porsche_json",
         "url": url,
         "engine": engine,


### PR DESCRIPTION
## Summary
- extend Cars & Bids importer to capture descriptions, highlight lists and full image galleries
- persist images_json and other descriptive fields during DB updates and other import scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e983bb988321a24cfeb175c4b2ff