### PR TITLE
Handle lot numbers in JSON import

### DIFF
--- a/backend/import_from_json.py
+++ b/backend/import_from_json.py
@@ -105,6 +105,12 @@ def normalize(item):
     seller_rating = seller.get("rating")
     seller_reviews = seller.get("reviews")
 
+    lot_number = item.get("lotNumber") or item.get("lot_number")
+    if not lot_number and url:
+        m = re.search(r"/auctions/([^/]+)/", url)
+        if m:
+            lot_number = m.group(1)
+
     # basic validation for our API
     if not (make and model and year and price is not None):
         return None


### PR DESCRIPTION
## Summary
- Safely extract `lot_number` in JSON import `normalize`
- Fallback to parsing from URL if `lotNumber` field is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b311c91314832185cd3d8823aa8de7