### PR TITLE
Ensure import_jobs table is created

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,7 +1,7 @@
 from sqlmodel import create_engine, SQLModel, Session
 from sqlalchemy import text
 from backend_settings import settings
-from models import Make, Model, Category, Dealership, Car
+from models import Make, Model, Category, Dealership, Car, ImportJob
 
 
 
@@ -76,6 +76,7 @@ def init_db():
             Category.__table__,
             Dealership.__table__,
             Car.__table__,
+            ImportJob.__table__,
         ],
     )
     ensure_columns()


### PR DESCRIPTION
## Summary
- include ImportJob in database initialization so the import_jobs table is created automatically

## Testing
- `python3 - <<'PY'
from backend.db import init_db
init_db()
print('init_db done')
PY` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pytest` *(fails: command not found)*
- `sqlite3 backend/cars.db '.tables'`

------
https://chatgpt.com/codex/tasks/task_e_68b311ba1c3c8321ad039abc064281bc